### PR TITLE
fix: ReactiveInputFieldのパース失敗時に値がdefault(T)へ上書きされる不具合を修正

### DIFF
--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/FloatReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/FloatReactiveInputField.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using UnityEngine;
 using TMPro;
 using R3;
@@ -30,12 +31,12 @@ namespace Nitou.ObservableUI
         // Protected Method
         protected override bool TryParseFromView(out float value)
         {
-            return float.TryParse(_inputField.text, out value);
+            return float.TryParse(_inputField.text, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
         }
 
         protected override void SetToView(float value)
         {
-            _inputField.text = value.ToString("F2");
+            _inputField.text = value.ToString("F2", CultureInfo.InvariantCulture);
         }
 
         protected override Observable<Unit> ObserveEndEditEvent()

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/IntReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/IntReactiveInputField.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using UnityEngine;
 using TMPro;
 using R3;
@@ -30,12 +31,12 @@ namespace Nitou.ObservableUI
         // Protected Method
         protected override bool TryParseFromView(out int value)
         {
-            return int.TryParse(_inputField.text, out value);
+            return int.TryParse(_inputField.text, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
         }
 
         protected override void SetToView(int value)
         {
-            _inputField.text = value.ToString();
+            _inputField.text = value.ToString(CultureInfo.InvariantCulture);
         }
 
         protected override Observable<Unit> ObserveEndEditEvent()

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/ReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/ReactiveInputField.cs
@@ -36,7 +36,9 @@ namespace Nitou.ObservableUI
                     if (TryParseFromView(out var value))
                         _property.Value = value;
                     else
-                        _property.OnNext(value);
+                        // パース失敗時は直前の有効値でViewを復元する
+                        // （ReactivePropertyの値は変えないため、下流への不要な通知は発生しない）
+                        SetToView(_property.Value);
                 })
                 .AddTo(this);
         }


### PR DESCRIPTION
## 概要

コードレビューで見つかった最優先のバグを修正します。

## 🔴 パース失敗時に値が `default(T)` へ上書きされる不具合

`ReactiveInputField<T>` で、InputFieldのパースに失敗した際、失敗時のout引数（`default(T)` = 0等）を `_property.OnNext(value)` に渡していました。R3の `ReactiveProperty.OnNext()` は等値チェックをスキップして内部の保持値も書き換えるため、**不正入力時に値が0にリセットされ、さらに下流のバインディングへ誤った変更通知が伝播**していました。

### 修正

```diff
- _property.OnNext(value);
+ // パース失敗時は直前の有効値でViewを復元する
+ // （ReactivePropertyの値は変えないため、下流への不要な通知は発生しない）
+ SetToView(_property.Value);
```

`OnNext` ではなく `SetToView(_property.Value)` を用いることで、保持値を変えず・下流へ誤通知せず、Viewだけを直前の有効値に戻します。

## 🟡 関連: カルチャ依存のパース／整形を統一

`Int`/`Float` の `TryParse`・`ToString` がカレントカルチャ依存でした。小数点記号がロケールで変わる環境ではView表示と再パースで往復が壊れ、上記のリセット処理が誤作動します。`CultureInfo.InvariantCulture` 基準に統一しました。

## 影響範囲

- `ReactiveInputField.cs`
- `IntReactiveInputField.cs`
- `FloatReactiveInputField.cs`

未使用APIの削除等は行っていません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hf2qPSs5iPyJjSkNMMSV2v)_