### PR TITLE
レビュー指摘の残課題対応（Vector実装 / スペル修正 / 例外メッセージ / ドキュメント）

### DIFF
--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/FloatReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/FloatReactiveInputField.cs
@@ -12,7 +12,7 @@ namespace Nitou.ObservableUI
         [SerializeField] protected TMP_InputField _inputField;
 
 
-        public override bool IsIntaractable
+        public override bool IsInteractable
         {
             get => _inputField.interactable;
             set => _inputField.interactable = value;

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/IntReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/IntReactiveInputField.cs
@@ -12,7 +12,7 @@ namespace Nitou.ObservableUI
         [SerializeField] protected TMP_InputField _inputField;
 
 
-        public override bool IsIntaractable
+        public override bool IsInteractable
         {
             get => _inputField.interactable;
             set => _inputField.interactable = value;

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/ReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/ReactiveInputField.cs
@@ -15,7 +15,7 @@ namespace Nitou.ObservableUI
 
         public ReactiveProperty<T> ReactiveProperty => _property;
 
-        public abstract bool IsIntaractable { get; set; }
+        public abstract bool IsInteractable { get; set; }
 
 
         /// ----------------------------------------------------------------------------

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/Vector2ReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/Vector2ReactiveInputField.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using UnityEngine;
 using TMPro;
 using R3;
@@ -11,7 +12,7 @@ namespace Nitou.ObservableUI
         [SerializeField] TMP_InputField _inputFieldY;
 
 
-        public override bool IsIntaractable
+        public override bool IsInteractable
         {
             get => _inputFieldX.interactable
                    && _inputFieldY.interactable;
@@ -36,13 +37,20 @@ namespace Nitou.ObservableUI
         // Protected Method
         protected override bool TryParseFromView(out Vector2 value)
         {
-            throw new NotImplementedException();
+            value = default;
+            if (float.TryParse(_inputFieldX.text, NumberStyles.Float, CultureInfo.InvariantCulture, out var x) &&
+                float.TryParse(_inputFieldY.text, NumberStyles.Float, CultureInfo.InvariantCulture, out var y))
+            {
+                value = new Vector2(x, y);
+                return true;
+            }
+            return false;
         }
 
         protected override void SetToView(Vector2 value)
         {
-            _inputFieldX.text = value.x.ToString("F2");
-            _inputFieldY.text = value.y.ToString("F2");
+            _inputFieldX.text = value.x.ToString("F2", CultureInfo.InvariantCulture);
+            _inputFieldY.text = value.y.ToString("F2", CultureInfo.InvariantCulture);
         }
 
         protected override Observable<Unit> ObserveEndEditEvent()

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/Vector3ReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/Vector3ReactiveInputField.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using UnityEngine;
 using TMPro;
 using R3;
@@ -12,7 +13,7 @@ namespace Nitou.ObservableUI
         [SerializeField] TMP_InputField _inputFieldZ;
 
 
-        public override bool IsIntaractable
+        public override bool IsInteractable
         {
             get => _inputFieldX.interactable
                    && _inputFieldY.interactable
@@ -40,15 +41,22 @@ namespace Nitou.ObservableUI
         // Protected Method
         protected override bool TryParseFromView(out Vector3 value)
         {
-            throw new NotImplementedException();
-            //return float.TryParse(_inputField.text, out value);
+            value = default;
+            if (float.TryParse(_inputFieldX.text, NumberStyles.Float, CultureInfo.InvariantCulture, out var x) &&
+                float.TryParse(_inputFieldY.text, NumberStyles.Float, CultureInfo.InvariantCulture, out var y) &&
+                float.TryParse(_inputFieldZ.text, NumberStyles.Float, CultureInfo.InvariantCulture, out var z))
+            {
+                value = new Vector3(x, y, z);
+                return true;
+            }
+            return false;
         }
 
         protected override void SetToView(Vector3 value)
         {
-            _inputFieldX.text = value.x.ToString("F2");
-            _inputFieldY.text = value.y.ToString("F2");
-            _inputFieldZ.text = value.z.ToString("F2");
+            _inputFieldX.text = value.x.ToString("F2", CultureInfo.InvariantCulture);
+            _inputFieldY.text = value.y.ToString("F2", CultureInfo.InvariantCulture);
+            _inputFieldZ.text = value.z.ToString("F2", CultureInfo.InvariantCulture);
         }
 
         protected override Observable<Unit> ObserveEndEditEvent()

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/ToggleExtensions.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/ToggleExtensions.cs
@@ -44,7 +44,8 @@ namespace R3
             int toggleCount = toggles.Count();
             int valueCount = values.Count();
             if (toggleCount == 0 || valueCount == 0 || toggleCount != valueCount)
-                throw new InvalidOperationException("");
+                throw new InvalidOperationException(
+                    $"togglesとvaluesは要素数が一致し、かつ空であってはいけません。(toggles: {toggleCount}, values: {valueCount})");
 
 
             var toggleValuePairs = toggles.Zip(values, (toggle, value) => (toggle, value));

--- a/ObservableUI/Assets/ObservableUI/Core/Interface/IReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Interface/IReactiveInputField.cs
@@ -9,6 +9,6 @@ namespace Nitou.ObservableUI
     public interface IReactiveInputField<T> : IReactivePropertyHolder<T>
         where T : struct
     {
-        bool IsIntaractable { get; set; }
+        bool IsInteractable { get; set; }
     }
 }

--- a/ObservableUI/CLAUDE.md
+++ b/ObservableUI/CLAUDE.md
@@ -7,9 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **ObservableUI** is a Unity package that extends R3 (Reactive Extensions for Unity) with reactive UI bindings for Unity's uGUI and TextMeshPro components. It provides bidirectional data binding, observable events, and reactive component wrappers for building reactive user interfaces in Unity.
 
 - **Package Name**: `jp.nitou.observableui`
-- **Version**: 1.0.0
+- **Version**: 1.1.0
 - **Unity Version**: 6000.0+ (Unity 6.2+)
-- **Current Branch**: `feature/switch-to-r3`
 - **Main Branch**: `main`
 
 ## Architecture
@@ -35,7 +34,7 @@ The framework consists of three main layers:
 1. **Reactive Components** (`Assets/ObservableUI/Core/Components/`)
    - `ReactiveInputField<T>`: Base class for type-safe reactive input fields
    - `IntReactiveInputField`, `FloatReactiveInputField`: Concrete implementations
-   - `Vector2ReactiveInputField`, `Vector3ReactiveInputField`: Multi-field inputs (incomplete)
+   - `Vector2ReactiveInputField`, `Vector3ReactiveInputField`: Multi-field inputs
    - `ReactiveEnumDropdown<TEnum>`: Reactive dropdown for enum selection
 
 2. **Interfaces** (`Assets/ObservableUI/Core/Interface/`)
@@ -126,8 +125,6 @@ Note: R3 uses `Disposable.Combine()` instead of `StableCompositeDisposable.Creat
 
 ## Known Incomplete Features
 
-- `Vector2ReactiveInputField.TryParseFromView()`: Throws `NotImplementedException`
-- `Vector3ReactiveInputField.TryParseFromView()`: Throws `NotImplementedException`
 - `Assets/ObservableUI/Localization/`: Empty directory
 - `Assets/ObservableUI/Core/Utilities/`: Empty directory
 


### PR DESCRIPTION
コードレビューで挙げた残りの改善項目を優先順位順に対応します。

## 🟡 1. Vector2/Vector3ReactiveInputField の実行時例外を解消（`2efec60`）

`TryParseFromView()` が `NotImplementedException` を送出しており、シーンに配置すると `Awake`/`OnEndEdit` で実行時例外が発生していました。各軸のInputFieldを個別に `InvariantCulture` 基準でパースし、Vectorへ合成する実装に置き換えました（いずれかの軸がパース失敗なら `false` を返し、基底クラスが直前の有効値でViewを復元します）。

## 🟡 2. 公開プロパティのスペル修正（`1f1060d`）

`IsIntaractable` → `IsInteractable`。インターフェースと全実装（Int/Float/Vector2/Vector3）を一括リネームしました。**公開APIの破壊的変更**ですが、早期修正のためこのタイミングで対応しています。

## 🟢 3. 例外メッセージの明文化（`958dcf2`）

`ToggleExtensions.BindToToggleGroup` で空だった `InvalidOperationException` のメッセージに、要素数不一致という原因と実際の件数を記載しました。

## 🟢 4. ドキュメント更新（`958dcf2`）

`CLAUDE.md` の version を 1.1.0 に反映し、古いブランチ記述と「Vector未完成」記述を更新しました。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hf2qPSs5iPyJjSkNMMSV2v)_