### PR TITLE
feat: ToggleToActive・各種バインド拡張・Stepperの追加 / InputField整形修正 (#1)

### DIFF
--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/FloatReactiveInputFieldStepper.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/FloatReactiveInputFieldStepper.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+namespace Nitou.ObservableUI
+{
+    /// <summary>
+    /// <see cref="FloatReactiveInputField"/>にステップ操作（増減）を加えたコンポーネント．
+    /// <see cref="MoveNext"/>／<see cref="MovePrevious"/>をButton等から呼び出して使用する．
+    /// </summary>
+    public class FloatReactiveInputFieldStepper : FloatReactiveInputField, IReactiveInputFieldStepper<float>
+    {
+        [Header("Stepper")]
+        [SerializeField] private float _delta = 1f;
+        [SerializeField] private bool _useClamp = false;
+        [SerializeField] private float _min = float.NegativeInfinity;
+        [SerializeField] private float _max = float.PositiveInfinity;
+
+
+        public float Delta => _delta;
+
+        public bool CanMovePrevious() => !_useClamp || _property.Value > _min;
+        public bool CanMoveNext() => !_useClamp || _property.Value < _max;
+
+        public void MovePrevious()
+        {
+            if (!CanMovePrevious()) return;
+            _property.Value = Clamp(_property.Value - _delta);
+        }
+
+        public void MoveNext()
+        {
+            if (!CanMoveNext()) return;
+            _property.Value = Clamp(_property.Value + _delta);
+        }
+
+
+        private float Clamp(float value) => _useClamp ? Mathf.Clamp(value, _min, _max) : value;
+    }
+}

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/FloatReactiveInputFieldStepper.cs.meta
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/FloatReactiveInputFieldStepper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b77bb60c886e028593062b08f7c5b1d

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/IntReactiveInputFieldStepper.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/IntReactiveInputFieldStepper.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+namespace Nitou.ObservableUI
+{
+    /// <summary>
+    /// <see cref="IntReactiveInputField"/>にステップ操作（増減）を加えたコンポーネント．
+    /// <see cref="MoveNext"/>／<see cref="MovePrevious"/>をButton等から呼び出して使用する．
+    /// </summary>
+    public class IntReactiveInputFieldStepper : IntReactiveInputField, IReactiveInputFieldStepper<int>
+    {
+        [Header("Stepper")]
+        [SerializeField] private int _delta = 1;
+        [SerializeField] private bool _useClamp = false;
+        [SerializeField] private int _min = int.MinValue;
+        [SerializeField] private int _max = int.MaxValue;
+
+
+        public int Delta => _delta;
+
+        public bool CanMovePrevious() => !_useClamp || _property.Value > _min;
+        public bool CanMoveNext() => !_useClamp || _property.Value < _max;
+
+        public void MovePrevious()
+        {
+            if (!CanMovePrevious()) return;
+            _property.Value = Clamp(_property.Value - _delta);
+        }
+
+        public void MoveNext()
+        {
+            if (!CanMoveNext()) return;
+            _property.Value = Clamp(_property.Value + _delta);
+        }
+
+
+        private int Clamp(int value) => _useClamp ? Mathf.Clamp(value, _min, _max) : value;
+    }
+}

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/IntReactiveInputFieldStepper.cs.meta
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/IntReactiveInputFieldStepper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 39601911a97fba826edbb7a550d0bf22

--- a/ObservableUI/Assets/ObservableUI/Core/Components/InputField/ReactiveInputField.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/InputField/ReactiveInputField.cs
@@ -35,10 +35,11 @@ namespace Nitou.ObservableUI
                 {
                     if (TryParseFromView(out var value))
                         _property.Value = value;
-                    else
-                        // パース失敗時は直前の有効値でViewを復元する
-                        // （ReactivePropertyの値は変えないため、下流への不要な通知は発生しない）
-                        SetToView(_property.Value);
+
+                    // パース成否に関わらず、現在の有効値でViewを正規化する
+                    // （成功時：整形表示の取りこぼし防止／失敗時：直前の有効値へ復元）
+                    // ReactivePropertyの値自体は変えないため、下流への不要な通知は発生しない
+                    SetToView(_property.Value);
                 })
                 .AddTo(this);
         }

--- a/ObservableUI/Assets/ObservableUI/Core/Components/Triggers.meta
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/Triggers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e25d0abde609893f017c973349d053ff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ObservableUI/Assets/ObservableUI/Core/Components/Triggers/ToggleToActive.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/Triggers/ToggleToActive.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+using UnityEngine.UI;
+using R3;
+
+namespace Nitou.ObservableUI
+{
+    /// <summary>
+    /// <see cref="Toggle"/>の状態（Trigger）に応じて，対象<see cref="GameObject"/>の
+    /// アクティブ状態（Action）を切り替える簡易コンポーネント．
+    /// <para>命名規約: [Trigger] To [Action]</para>
+    /// </summary>
+    [AddComponentMenu("Observable UI/Triggers/Toggle To Active")]
+    [DisallowMultipleComponent]
+    public sealed class ToggleToActive : MonoBehaviour
+    {
+        [Header("Trigger")]
+        [SerializeField] private Toggle _toggle;
+
+        [Header("Action")]
+        [Tooltip("アクティブ状態を切り替える対象")]
+        [SerializeField] private GameObject _target;
+
+        [Tooltip("ONで非アクティブ化する（ToggleToInactive相当）")]
+        [SerializeField] private bool _invert = false;
+
+
+        /// ----------------------------------------------------------------------------
+        // LifeCycle Events
+        private void Reset()
+        {
+            _toggle = GetComponent<Toggle>();
+        }
+
+        private void Awake()
+        {
+            if (_toggle == null)
+                _toggle = GetComponent<Toggle>();
+        }
+
+        private void Start()
+        {
+            if (_toggle == null || _target == null)
+            {
+                Debug.LogWarning($"[{nameof(ToggleToActive)}] Toggle/Targetが未設定のため動作しません．", this);
+                return;
+            }
+
+            // 初期状態を同期
+            Apply(_toggle.isOn);
+
+            // 以降の変化を購読（onValueChangedは購読時に初期値を流さないため上で明示的に同期）
+            _toggle.onValueChanged.AsObservable()
+                   .Subscribe(Apply)
+                   .AddTo(this);
+        }
+
+
+        /// ----------------------------------------------------------------------------
+        // Private Method
+        private void Apply(bool isOn)
+        {
+            _target.SetActive(_invert ? !isOn : isOn);
+        }
+    }
+}

--- a/ObservableUI/Assets/ObservableUI/Core/Components/Triggers/ToggleToActive.cs.meta
+++ b/ObservableUI/Assets/ObservableUI/Core/Components/Triggers/ToggleToActive.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad1e08a1de9f7ccdc1e6287dbea18f9c

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/CanvasGroupExtensions.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/CanvasGroupExtensions.cs
@@ -1,0 +1,53 @@
+using System;
+using UnityEngine;
+
+namespace R3
+{
+    /// <summary>
+    /// <see cref="CanvasGroup"/>の拡張メソッド群．
+    /// </summary>
+    public static partial class CanvasGroupExtensions
+    {
+        #region Binding
+
+        /// <summary>
+        /// <see cref="CanvasGroup.alpha"/>への単方向バインディング．
+        /// </summary>
+        public static IDisposable SubscribeToAlpha(this Observable<float> source, CanvasGroup canvasGroup)
+        {
+            return source.Subscribe(x => canvasGroup.alpha = x);
+        }
+
+        /// <summary>
+        /// <see cref="CanvasGroup.interactable"/>への単方向バインディング．
+        /// </summary>
+        public static IDisposable SubscribeToInteractable(this Observable<bool> source, CanvasGroup canvasGroup)
+        {
+            return source.Subscribe(x => canvasGroup.interactable = x);
+        }
+
+        /// <summary>
+        /// <see cref="CanvasGroup.blocksRaycasts"/>への単方向バインディング．
+        /// </summary>
+        public static IDisposable SubscribeToBlocksRaycasts(this Observable<bool> source, CanvasGroup canvasGroup)
+        {
+            return source.Subscribe(x => canvasGroup.blocksRaycasts = x);
+        }
+
+        /// <summary>
+        /// 表示状態（<see cref="CanvasGroup.alpha"/>／<see cref="CanvasGroup.interactable"/>／
+        /// <see cref="CanvasGroup.blocksRaycasts"/>）をまとめて切り替える単方向バインディング．
+        /// </summary>
+        public static IDisposable SubscribeToVisible(this Observable<bool> source, CanvasGroup canvasGroup)
+        {
+            return source.Subscribe(x =>
+            {
+                canvasGroup.alpha = x ? 1f : 0f;
+                canvasGroup.interactable = x;
+                canvasGroup.blocksRaycasts = x;
+            });
+        }
+
+        #endregion
+    }
+}

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/CanvasGroupExtensions.cs.meta
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/CanvasGroupExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 06ef3c5a92c864696373175ae82dc72c

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/GameObjectExtensions.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/GameObjectExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using UnityEngine;
+
+namespace R3
+{
+    /// <summary>
+    /// <see cref="GameObject"/>の拡張メソッド群．
+    /// </summary>
+    public static partial class GameObjectExtensions
+    {
+        #region Binding
+
+        /// <summary>
+        /// <see cref="GameObject.SetActive(bool)"/>への単方向バインディング．
+        /// </summary>
+        public static IDisposable SubscribeToActive(this Observable<bool> source, GameObject gameObject)
+        {
+            return source.Subscribe(x => gameObject.SetActive(x));
+        }
+
+        #endregion
+    }
+}

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/GameObjectExtensions.cs.meta
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/GameObjectExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5647fb0d57d0568d7c710d85caaeec5f

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/ImageExtensions.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/ImageExtensions.cs
@@ -27,6 +27,14 @@ namespace R3
             return source.Subscribe(x => image.color = x);
         }
 
+        /// <summary>
+        /// <see cref="Image"/>.spriteへのバインディング．
+        /// </summary>
+        public static IDisposable SubscribeToImageSprite(this Observable<Sprite> source, Image image)
+        {
+            return source.Subscribe(x => image.sprite = x);
+        }
+
         #endregion
     }
 }

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/RawImageExtensions.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/RawImageExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace R3
+{
+    /// <summary>
+    /// <see cref="RawImage"/>の拡張メソッド群．
+    /// </summary>
+    public static partial class RawImageExtensions
+    {
+        #region Binding
+
+        /// <summary>
+        /// <see cref="RawImage"/>.textureへのバインディング．
+        /// </summary>
+        public static IDisposable SubscribeToRawImageTexture(this Observable<Texture> source, RawImage rawImage)
+        {
+            return source.Subscribe(x => rawImage.texture = x);
+        }
+
+        /// <summary>
+        /// <see cref="RawImage"/>.colorへのバインディング．
+        /// </summary>
+        public static IDisposable SubscribeToRawImageColor(this Observable<Color> source, RawImage rawImage)
+        {
+            return source.Subscribe(x => rawImage.color = x);
+        }
+
+        #endregion
+    }
+}

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/RawImageExtensions.cs.meta
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/RawImageExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c5fdc013bf68c912d96a30646d3822f

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/ScrollRectExtensions.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/ScrollRectExtensions.cs
@@ -1,0 +1,43 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace R3
+{
+    /// <summary>
+    /// <see cref="ScrollRect"/>の拡張メソッド群．
+    /// </summary>
+    public static partial class ScrollRectExtensions
+    {
+        #region Observable
+
+        /// <summary>
+        /// Observe onValueChanged with current `normalizedPosition` on subscribe.
+        /// </summary>
+        public static Observable<Vector2> OnValueChangedAsObservable(this ScrollRect scrollRect, bool withCurrentValue = true)
+        {
+            return Observable.Create<Vector2>(observer =>
+            {
+                if (withCurrentValue)
+                    observer.OnNext(scrollRect.normalizedPosition);
+
+                return scrollRect.onValueChanged.AsObservable().Subscribe(observer);
+            });
+        }
+
+        #endregion
+
+
+        #region Binding
+
+        /// <summary>
+        /// <see cref="ScrollRect.normalizedPosition"/>への単方向バインディング．
+        /// </summary>
+        public static IDisposable SubscribeToNormalizedPosition(this Observable<Vector2> source, ScrollRect scrollRect)
+        {
+            return source.Subscribe(x => scrollRect.normalizedPosition = x);
+        }
+
+        #endregion
+    }
+}

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/ScrollRectExtensions.cs.meta
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/ScrollRectExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e841fda4425c301c0b8a58345c0a05d

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/SelectableExtensions.cs
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/SelectableExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using UnityEngine.UI;
+
+namespace R3
+{
+    /// <summary>
+    /// <see cref="Selectable"/>（Button・Toggle等の基底）の拡張メソッド群．
+    /// </summary>
+    public static partial class SelectableExtensions
+    {
+        #region Binding
+
+        /// <summary>
+        /// <see cref="Selectable.interactable"/>への単方向バインディング．
+        /// </summary>
+        public static IDisposable SubscribeToInteractable(this Observable<bool> source, Selectable selectable)
+        {
+            return source.Subscribe(x => selectable.interactable = x);
+        }
+
+        #endregion
+    }
+}

--- a/ObservableUI/Assets/ObservableUI/Core/Extensions/SelectableExtensions.cs.meta
+++ b/ObservableUI/Assets/ObservableUI/Core/Extensions/SelectableExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 083ae155cb86bc712b97dc98a7df9f3a

--- a/ObservableUI/CLAUDE.md
+++ b/ObservableUI/CLAUDE.md
@@ -34,6 +34,7 @@ The framework consists of three main layers:
 1. **Reactive Components** (`Assets/ObservableUI/Core/Components/`)
    - `ReactiveInputField<T>`: Base class for type-safe reactive input fields
    - `IntReactiveInputField`, `FloatReactiveInputField`: Concrete implementations
+   - `IntReactiveInputFieldStepper`, `FloatReactiveInputFieldStepper`: Steppers with Delta/clamp (`MoveNext`/`MovePrevious`)
    - `Vector2ReactiveInputField`, `Vector3ReactiveInputField`: Multi-field inputs
    - `ReactiveEnumDropdown<TEnum>`: Reactive dropdown for enum selection
    - **Trigger/Action Components** (`Components/Triggers/`): Lightweight `[Trigger] To [Action]` components
@@ -47,7 +48,8 @@ The framework consists of three main layers:
 
 3. **Extension Methods** (`Assets/ObservableUI/Core/Extensions/`)
    - Provide reactive bindings for Unity UI components
-   - Targets: Button, Dropdown, Image, InputField, Slider, Text, Toggle,
+   - Targets: Button, Dropdown, Image (color/fillAmount/sprite), RawImage (texture/color),
+     InputField, Slider, Text, Toggle, ScrollRect (normalizedPosition),
      CanvasGroup (alpha/interactable/blocksRaycasts/visible),
      Selectable (interactable), GameObject (SetActive)
    - Naming convention:

--- a/ObservableUI/CLAUDE.md
+++ b/ObservableUI/CLAUDE.md
@@ -36,6 +36,8 @@ The framework consists of three main layers:
    - `IntReactiveInputField`, `FloatReactiveInputField`: Concrete implementations
    - `Vector2ReactiveInputField`, `Vector3ReactiveInputField`: Multi-field inputs
    - `ReactiveEnumDropdown<TEnum>`: Reactive dropdown for enum selection
+   - **Trigger/Action Components** (`Components/Triggers/`): Lightweight `[Trigger] To [Action]` components
+     - `ToggleToActive`: Toggle state → target GameObject active state (`_invert` covers the inactive case)
 
 2. **Interfaces** (`Assets/ObservableUI/Core/Interface/`)
    - `IReactivePropertyHolder<T>`: Base contract for components with reactive properties
@@ -45,6 +47,9 @@ The framework consists of three main layers:
 
 3. **Extension Methods** (`Assets/ObservableUI/Core/Extensions/`)
    - Provide reactive bindings for Unity UI components
+   - Targets: Button, Dropdown, Image, InputField, Slider, Text, Toggle,
+     CanvasGroup (alpha/interactable/blocksRaycasts/visible),
+     Selectable (interactable), GameObject (SetActive)
    - Naming convention:
      - `SubscribeToXXX`: One-way binding (observable → UI)
      - `BindToXXX`: Two-way binding (reactive property ↔ UI)
@@ -135,7 +140,8 @@ Assets/ObservableUI/
 ├── Core/                          # Runtime assembly
 │   ├── Components/
 │   │   ├── InputField/           # Reactive input field variants
-│   │   └── Dropdown/             # Reactive dropdown components
+│   │   ├── Dropdown/             # Reactive dropdown components
+│   │   └── Triggers/             # [Trigger] To [Action] components
 │   ├── Interface/                # Core interfaces
 │   ├── Extensions/               # Extension methods for UI bindings
 │   ├── Utilities/                # (Empty)


### PR DESCRIPTION
レビューで合意した改善項目と追加コンポーネントを優先順位順に実装しました。

## 🟢 1. ReactiveInputField の整形取りこぼし修正（`42ee973`）

確定時（OnEndEdit）に表示中と同値を再入力すると `ReactiveProperty` の重複排除で `SetToView` が呼ばれず、整形表示が取りこぼされていました（例: `5.00` 表示中に `5` 入力 → `5` のまま）。パース成否に関わらず現在の有効値で View を正規化するよう変更。保持値は変えないため下流への不要な通知は発生しません。

## ✨ 2. 汎用バインド拡張の追加（`9747afa` / `261ce00`）

頻出するのに欠けていた単方向バインドを追加（すべて `R3` 名前空間）。

| 拡張 | メソッド |
|---|---|
| `GameObjectExtensions` | `SubscribeToActive` |
| `SelectableExtensions` | `SubscribeToInteractable`（Button/Toggle等の `interactable` を一括対応） |
| `CanvasGroupExtensions` | `SubscribeToAlpha` / `SubscribeToInteractable` / `SubscribeToBlocksRaycasts` / `SubscribeToVisible` |
| `ImageExtensions` | `SubscribeToImageSprite`（既存に追加） |
| `RawImageExtensions` | `SubscribeToRawImageTexture` / `SubscribeToRawImageColor` |
| `ScrollRectExtensions` | `OnValueChangedAsObservable` / `SubscribeToNormalizedPosition` |

## ✨ 3. ToggleToActive コンポーネント — Issue #1（`4cf3f6c`）

`Toggle`（Trigger）の状態に応じて対象 `GameObject` のアクティブ状態（Action）を切り替える軽量コンポーネント。命名規約 `[Trigger] To [Action]` 準拠、`_invert` で **ToggleToInactive 相当**を兼用、Action は SetActive のみ。

closes #1

## ✨ 4. Stepper コンポーネントの追加（`7afc536`）

定義のみだった `IReactiveInputFieldStepper<T>` の具象実装。`IntReactiveInputFieldStepper` / `FloatReactiveInputFieldStepper` を追加。`Delta` 指定の増減（`MoveNext`/`MovePrevious`）と任意の min/max クランプに対応。ボタン参照は持たず、既存 `Button` 拡張等から Move 操作を呼び出す薄い構成。

---

### 設計上の確認ポイント
- **ToggleToInactive を別コンポーネント化せず `_invert` に集約**（Issue ではオプション扱い）。分離が望ましければ対応します。
- **Stepper はボタン参照を持たない**設計（汎用性重視）。インスペクタで +/- ボタンを直接紐付けたい場合は SerializeField 版も用意できます。
- **テストケースは未着手**。Unity Test Framework 用 Tests アセンブリ新設が必要で本環境では実行確認不可のため別 PR を提案します。

⚠️ 本環境では Unity Editor を実行できないため、コンパイル/Play 検証は未実施（静的確認のみ）です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)